### PR TITLE
Fix video generator init and multi‑language pipeline

### DIFF
--- a/backend/localization/multi_language_pipeline.py
+++ b/backend/localization/multi_language_pipeline.py
@@ -46,7 +46,11 @@ class MultiLanguagePipelineManager:
             async_manager = get_async_pipeline_manager()
             
             base_result = await async_manager.execute_pipeline_async(scenes, base_config)
-            if not base_result.get("success", False):
+
+            if isinstance(base_result, str):
+                base_result = {"success": True, "output_path": base_result}
+
+            if not isinstance(base_result, dict) or not base_result.get("success", False):
                 raise Exception("Base video generation failed")
             
             logger.info("Base video generation completed successfully")
@@ -125,8 +129,11 @@ class MultiLanguagePipelineManager:
         async_manager = get_async_pipeline_manager()
         
         audio_result = await async_manager.execute_pipeline_async(translated_scenes, lang_config)
-        
-        if not audio_result.get("success", False):
+
+        if isinstance(audio_result, str):
+            audio_result = {"success": True, "output_path": audio_result}
+
+        if not isinstance(audio_result, dict) or not audio_result.get("success", False):
             raise Exception(f"Audio generation failed for {language_code}")
         
         await self._combine_video_with_audio(base_output_path, lang_output_dir, language_code, lang_config)
@@ -171,11 +178,16 @@ class MultiLanguagePipelineManager:
                 logger.info(f"Generating short {i+1} for {language_code}")
                 
                 short_result = await async_manager.execute_pipeline_async([scene], short_config)
-                
+
+                if isinstance(short_result, str):
+                    short_result = {"success": True, "output_path": short_result}
+
                 if short_result.get("success"):
                     logger.info(f"Short {i+1} generated successfully for {language_code}")
                 else:
-                    logger.error(f"Short {i+1} generation failed for {language_code}: {short_result.get('error')}")
+                    logger.error(
+                        f"Short {i+1} generation failed for {language_code}: {short_result.get('error')}"
+                    )
                 
         except Exception as e:
             logger.error(f"Shorts generation failed for {language_code}: {e}")

--- a/backend/pipelines/channel_specific/base_pipeline.py
+++ b/backend/pipelines/channel_specific/base_pipeline.py
@@ -1236,6 +1236,15 @@ Focus on creating prompts that will generate the highest quality {channel_type} 
             
         except Exception as e:
             logger.error(f"Error logging script processing failure: {e}")
+
+    def _get_model_settings(self) -> Dict[str, Any]:
+        """Return model settings for TextToVideoGenerator."""
+        return {
+            "base_model": self.base_model,
+            "device": self.device,
+            "dtype": self.dtype,
+            "vram_tier": self.vram_tier,
+        }
     
     def generate_video(self, prompt: str, duration: float = 5.0, output_path: Optional[str] = None,
                        lora_paths: Optional[List[str]] = None) -> Optional[str]:
@@ -1245,11 +1254,12 @@ Focus on creating prompts that will generate the highest quality {channel_type} 
         
         try:
             from ..text_to_video_generator import TextToVideoGenerator
-            
+
             if not hasattr(self, 'video_generator') or self.video_generator is None:
                 self.video_generator = TextToVideoGenerator(
                     vram_tier=self.vram_tier,
-                    target_resolution=(1920, 1080)
+                    target_resolution=(1920, 1080),
+                    model_settings=self._get_model_settings(),
                 )
 
             if lora_paths:

--- a/backend/pipelines/text_to_video_generator.py
+++ b/backend/pipelines/text_to_video_generator.py
@@ -24,9 +24,15 @@ logger = logging.getLogger(__name__)
 
 class TextToVideoGenerator:
     """Real text-to-video generation using actual AI models."""
-    
-    def __init__(self, vram_tier: str = "medium", target_resolution: Tuple[int, int] = (1920, 1080)):
+
+    def __init__(
+        self,
+        vram_tier: str = "medium",
+        target_resolution: Tuple[int, int] = (1920, 1080),
+        model_settings: Optional[Dict[str, Any]] = None,
+    ):
         from config import DEFAULT_VIDEO_MODEL
+
         self.vram_tier = vram_tier
         self.target_resolution = target_resolution
         self.device = "cuda" if torch.cuda.is_available() else "cpu"
@@ -35,6 +41,11 @@ class TextToVideoGenerator:
         self.current_model = None
         self.fallback_model = DEFAULT_VIDEO_MODEL
         self.lora_paths = []
+        self.model_settings = model_settings or {}
+
+        if not self.model_settings:
+            # Initialize default model settings so later methods don't fail
+            self.apply_lora_models([])
 
     def apply_lora_models(self, lora_paths: List[str]):
         """Store LoRA model paths for later use."""


### PR DESCRIPTION
## Summary
- set up `TextToVideoGenerator` with optional model settings and default fallback
- supply model settings from `BasePipeline`
- accept string results in `MultiLanguagePipelineManager`

## Testing
- `python run_comprehensive_tests.py` *(fails: No such file or directory '/home/ubuntu/repos/ai-manager-app')*

------
https://chatgpt.com/codex/tasks/task_e_68569cf74f58832bb276b1da0c8823a2